### PR TITLE
Added `fields` mandatory for AWS ecr scanner

### DIFF
--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -379,7 +379,7 @@
           "$ref": "#/definitions/source.aws_ecr.fields"
         }
       },
-      "required": ["type", "configuration"]
+      "required": ["type", "configuration", "fields"]
     },
     "source.aws_ecr.fields": {
       "type": "array",


### PR DESCRIPTION
Added `fields` mandatory for AWS ecr scanner