### PR TITLE
Add templates for pull requests and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**To Reproduce**
+If it's a bug, explain how to reproduce it.
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What type of PR is this? (check all applicable)
+
+- [ ] Refactor
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Documentation Update
+
+## Description
+
+Please provide some description about your PR.
+
+## Related Issue (if applicable)
+
+## Added tests?
+
+- [ ] Yes
+- [ ] No, and this is why: please replace this line with details on why tests
+  have not been included
+- [ ] I need help with writing tests
+
+## Relevant Documentation updated?
+
+- [ ] [Docs](link to the docs pr)
+- [ ] Did not update documentation


### PR DESCRIPTION
This PR introduces two new templates for GitHub: one for pull requests, the other for issues. These templates will help provide structure and consistency when contributors create new pull requests or issues, improving the quality of information received.